### PR TITLE
feat: structured logging, message context, and chunking enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
+ "itertools 0.14.0",
  "log",
  "lz4",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,9 @@ dependencies = [
  "tokio-console",
  "tokio-util",
  "toml 0.8.20",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
  "zstd",
 ]
 
@@ -1156,6 +1159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,8 +1577,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1577,8 +1598,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1884,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2139,17 +2166,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2215,6 +2259,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 default = []
 pretty-logs = []
 [dependencies]
+itertools = "0.14.0" # Add itertools crate
 rand = "0.9.0"
 thiserror = "2.0.12"
 nix = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "coentrovpn"
 version = "0.1.0"
 edition = "2021"
+[features]
+default = []
+pretty-logs = []
 [dependencies]
 rand = "0.9.0"
 thiserror = "2.0.12"
@@ -11,7 +14,8 @@ lz4 = "1.24.0"
 zstd = "0.13.3"
 num_cpus = {version = "1.13"}
 tokio-console = "0.1.13"
-tokio = { version = "1.44.1", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
+uuid = { version = "1.8", features = ["v4"] }
 async-trait = "0.1"
 log = "0.4"
 env_logger = "0.11.8"
@@ -21,3 +25,5 @@ clap = { version = "4.5.35", features = ["derive"] }
 toml = "0.8"
 futures = "0.3"   # For async operations
 tokio-util = "0.7"  # For async utilities
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }

--- a/Config.toml
+++ b/Config.toml
@@ -4,7 +4,7 @@ listen_addr = "0.0.0.0"
 listen_port = 1194
 
 [logging]
-log_level = "debug"  # Possible values: "debug", "info", "error", etc.
+log_level = "info"  # Possible values: "debug", "info", "error", etc.
 
 [compression]
 algorithm = "lz4"  # Possible values: "lz4", "zstd"

--- a/src/client.rs
+++ b/src/client.rs
@@ -39,6 +39,8 @@ impl Clone for Client {
 #[async_trait]
 impl Tunnel for Client {
     async fn start(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {  // mutable self
+        let span = info_span!("client_start", session_id = %self.session_id);
+        let _enter = span.enter();
         let local = "0.0.0.0:0"; // Bind to a random port
         let server = format!("{}:{}", self.config.server_addr, self.config.listen_port);
         

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,11 +12,16 @@ use std::sync::Arc;
 use std::net::SocketAddr;
 use tokio::time::{sleep, Duration}; // For rate limiting
 use crate::packet_utils::{frame_chunks, deframe_chunks}; // Updated import
+use crate::context::{MessageContext, MessageType}; // Added import
+use tracing::info_span; // Added import
+use std::fmt; // Added import for Display implementation
+use uuid::Uuid; // Add near the top
 
 pub struct Client {
     pub config: Config,
-    pub socket: Arc<Mutex<UdpSocket>>,  // Add socket field to Client
+    pub socket: Arc<Mutex<UdpSocket>>,
     pub server_addr: SocketAddr,
+    pub session_id: Uuid, // Fix session_id to use Uuid
 }
 
 // Implement Clone for Client
@@ -26,6 +31,7 @@ impl Clone for Client {
             config: self.config.clone(),
             socket: Arc::clone(&self.socket),
             server_addr: self.server_addr,
+            session_id: self.session_id, // Clone session_id
         }
     }
 }
@@ -137,9 +143,28 @@ impl Tunnel for Client {
         let enable = self.config.udp.enable_mtu_discovery.unwrap_or(false);
         let discovered_mtu = discover_path_mtu(configured_mtu.into(), addr, enable);
         let max_packet_size = self.config.udp.max_packet_size.unwrap_or_else(|| calculate_max_payload_size(discovered_mtu));
+        
+        info!("Using max_packet_size: {}", max_packet_size); // Moved line
 
         let socket = self.socket.lock().await;  // Lock the socket for sending
         
+        let msg_id: u32 = rand::random(); // Updated to generate message ID
+        let msg_ctx = MessageContext {
+            message_id: msg_id as u64,
+            session_id: self.session_id,
+            size: data.len(),
+            message_type: MessageType::Data,
+        };
+
+        let span = info_span!(
+            "message_send",
+            message_id = msg_ctx.message_id,
+            session_id = %msg_ctx.session_id,
+            message_type = %msg_ctx.message_type,
+            size = msg_ctx.size
+        );
+        let _enter = span.enter();
+
         // Apply rate limiting based on configuration
         if let Some(rate_limit) = self.config.udp.rate_limit {
             let rate_limit_bytes = rate_limit as f64;
@@ -160,7 +185,6 @@ impl Tunnel for Client {
             socket.send_to(data, addr).await?;
         } else {
             // Update MTU-based packet sizing
-            let msg_id: u32 = rand::random(); // Updated to generate message ID
             let chunks = frame_chunks(data, max_packet_size - 8, msg_id); // Updated to frame chunks
 
             // Send each chunk
@@ -191,8 +215,26 @@ impl Tunnel for Client {
         // Check if received data fits within max packet size
         let reassembled_data = match deframe_chunks(vec![buf[..size].to_vec()]) { // Updated to use deframe_chunks
             Some(data) => data,
-            None => return Err("Failed to reassemble packet".into()),
+            None => {
+                error!("Deframe failed for received packet, discarding");
+                return Err("Failed to reassemble packet".into());
+            }
         };
+
+        let msg_ctx = MessageContext {
+            message_id: 0, // TODO: parse actual message_id from chunk when available
+            session_id: self.session_id,
+            size: reassembled_data.len(),
+            message_type: MessageType::Data,
+        };
+
+        let span = info_span!(
+            "message_receive",
+            session_id = %msg_ctx.session_id,
+            message_type = %msg_ctx.message_type,
+            size = msg_ctx.size
+        );
+        let _enter = span.enter();
 
         Ok(reassembled_data)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use crate::net::{calculate_max_payload_size, discover_path_mtu};
 use socket2::Socket;
 use std::net::UdpSocket as StdUdpSocket;
 use async_trait::async_trait;
-use log::{info, error};
+use tracing::{info, error, warn, trace};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 use tokio::task;
@@ -88,12 +88,17 @@ impl Tunnel for Client {
                 let rate_limit_bytes = rate_limit as f64;
 
                 let sent_data = message.len() as f64;
-                let sleep_duration = Duration::from_secs_f64(sent_data / rate_limit_bytes);
+                let sleep_duration = if rate_limit_bytes > 0.0 {
+                    Duration::from_secs_f64(sent_data / rate_limit_bytes)
+                } else {
+                    Duration::from_secs(0)
+                };
 
                 // Sleep to respect the rate limit
                 sleep(sleep_duration).await;
             }
 
+            trace!("Sending message to server: {}", String::from_utf8_lossy(message));
             if message.len() <= max_packet_size {
                 match socket.send_to(message, &client_clone.server_addr).await {
                     Ok(_) => {
@@ -140,7 +145,11 @@ impl Tunnel for Client {
             let rate_limit_bytes = rate_limit as f64;
 
             let sent_data = data.len() as f64;
-            let sleep_duration = Duration::from_secs_f64(sent_data / rate_limit_bytes);
+            let sleep_duration = if rate_limit_bytes > 0.0 {
+                Duration::from_secs_f64(sent_data / rate_limit_bytes)
+            } else {
+                Duration::from_secs(0)
+            };
 
             // Sleep to respect the rate limit
             sleep(sleep_duration).await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use std::fs;
 use std::env;
+use tracing::{info, error, warn};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct LoggingConfig {
@@ -38,8 +39,15 @@ pub struct Config {
 
 impl Config {
     pub fn from_file(path: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        let contents = fs::read_to_string(path)?;
-        let config: Config = toml::from_str(&contents)?;
+        info!("Loading config from {}", path);
+        let contents = fs::read_to_string(path).map_err(|e| {
+            error!("Failed to load config from {}: {}", path, e);
+            e
+        })?;
+        let config: Config = toml::from_str(&contents).map_err(|e| {
+            error!("Failed to parse config from {}: {}", path, e);
+            e
+        })?;
         Ok(config)
     }
 
@@ -57,7 +65,13 @@ impl Config {
             config.listen_addr = listen_addr;
         }
         if let Ok(listen_port) = env::var("LISTEN_PORT") {
-            config.listen_port = listen_port.parse().unwrap_or(config.listen_port);
+            config.listen_port = match listen_port.parse() {
+                Ok(port) => port,
+                Err(_) => {
+                    warn!("Invalid LISTEN_PORT '{}', falling back to {}", listen_port, config.listen_port);
+                    config.listen_port
+                }
+            };
         }
         if let Ok(log_level) = env::var("LOG_LEVEL") {
             config.logging.log_level = log_level;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Direction {
+    Inbound,
+    Outbound,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageContext {
+    pub message_id: u64,
+    pub session_id: Uuid,
+    pub size: usize,
+    pub message_type: MessageType,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChunkContext {
+    pub message_id: u64,
+    pub chunk_id: u32,
+    pub total_chunks: Option<u32>,
+    pub direction: Direction,
+}
+
+#[derive(Debug, Clone)]
+pub enum MessageType {
+    Control,
+    Data,
+    Handshake,
+    Heartbeat,
+    #[allow(dead_code)]
+    Unknown(u8),
+}
+
+impl fmt::Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Direction::Inbound => write!(f, "inbound"),
+            Direction::Outbound => write!(f, "outbound"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    pub session_id: Uuid,
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,7 @@ impl fmt::Display for Direction {
     }
 }
 
+
 #[derive(Debug, Clone)]
 pub struct SessionContext {
     pub session_id: Uuid,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use uuid::Uuid;
+use std::net::SocketAddr;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Direction {
@@ -46,4 +47,5 @@ impl fmt::Display for Direction {
 #[derive(Debug, Clone)]
 pub struct SessionContext {
     pub session_id: Uuid,
+    pub peer_addr: Option<SocketAddr>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@ pub mod server;
 pub mod client;
 pub mod net;
 pub mod packet_utils;
+pub mod logging;
+pub mod context;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,18 @@
+use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::fmt::format::FmtSpan;
+
+pub fn init_logging(level: &str) {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(level));
+
+    let builder = fmt()
+        .with_env_filter(env_filter)
+        .with_span_events(FmtSpan::ENTER | FmtSpan::CLOSE)
+        .with_target(true);
+
+    #[cfg(feature = "pretty-logs")]
+    builder.pretty().init();
+
+    #[cfg(not(feature = "pretty-logs"))]
+    builder.json().init();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,12 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
             }
             "client" => {
                 let server_addr = config.server_addr.parse()?;
-                let mut client: Client = Client { config, socket: Arc::clone(&socket), server_addr };
+                let mut client: Client = Client {
+                    config,
+                    socket: Arc::clone(&socket),
+                    server_addr,
+                    session_id: Uuid::new_v4(),
+                };
                 client.start().await?;  // Now we can call start() on a mutable reference
             }
             _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
-use log::{info, debug};
+use tracing::{info, debug}; // Updated import
+use uuid::Uuid;
 use std::env;
 use num_cpus;  // Import the num_cpus crate
 use tokio::runtime::Builder;  // Import Builder to manually create the runtime
@@ -10,6 +11,7 @@ use coentrovpn::config::Config;
 use coentrovpn::client::Client;
 use coentrovpn::server::Server;
 use coentrovpn::tunnel::Tunnel;
+use coentrovpn::logging::init_logging; // Updated import
 
 
 #[derive(Parser, Debug)]
@@ -40,10 +42,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         let config = Config::from_env_or_file(&cli.config)?;
         info!("Config loaded: {:?}", config);
 
-        // Check environment variable `LOG_LEVEL` first
-        let log_level = match env::var("LOG_LEVEL") {
-            Ok(val) => val.to_lowercase(),
-            Err(_) => config.logging.log_level.to_lowercase(),  // Fall back to Config.toml
+        // Check environment variable `LOG_LEVEL` first, then fallback to Config.toml
+        let log_level = if let Ok(val) = env::var("LOG_LEVEL") {
+            val.to_lowercase()
+        } else {
+            config.logging.log_level.to_lowercase()
         };
 
         // Ensure a valid log level is set
@@ -54,13 +57,16 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
             _ => "info",  // Default to info if invalid value found
         };
 
-        // Set RUST_LOG environment variable for logging
-        env::set_var("RUST_LOG", log_level);
+        // Only set RUST_LOG if it's not already set
+        if env::var("RUST_LOG").is_err() {
+            env::set_var("RUST_LOG", &log_level);
+        }
         
         // Debug log to verify the log level
+
+        init_logging(&log_level); // Replaced env_logger::init() with init_logging()
         debug!("Log level set to: {}", log_level);
-        debug!("RUST_LOG is set to: {}", env::var("RUST_LOG").unwrap_or_else(|_| "not set".to_string()));
-        env_logger::init();
+        debug!("RUST_LOG is set to: {}", env::var("RUST_LOG").unwrap_or_else(|_| "not set".to_string()));        
 
         // Create a UDP socket and wrap it in an Arc<Mutex>
         let socket = UdpSocket::bind("0.0.0.0:0").await?;  // Bind to a random available port
@@ -69,7 +75,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         // Instantiate Client or Server based on mode
         match config.mode.as_str() {
             "server" => {
-                let mut server: Server = Server { config, socket: Arc::clone(&socket) }; // Declare server as mutable
+                let mut server: Server = Server {
+                    config,
+                    socket: Arc::clone(&socket),
+                    session_id: Uuid::new_v4(),
+                }; // Declare server as mutable
                 server.start().await?;  // Now we can call start() on a mutable reference
             }
             "client" => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,8 +11,10 @@ use tokio::time::{sleep, Duration}; // For rate limiting
 use socket2::Socket;
 use std::net::UdpSocket as StdUdpSocket;
 use crate::packet_utils::{split_packet, frame_chunks, deframe_chunks};
-use crate::context::{Direction, ChunkContext}; // Added imports
+use crate::context::{Direction, ChunkContext, MessageContext, MessageType}; // Added imports
 use uuid::Uuid; // Add this at the top
+use tracing::info_span; // Added import
+use std::fmt; // Added import for Display implementation
 
 pub struct Server {
     pub config: Config,
@@ -114,6 +116,23 @@ impl Tunnel for Server {
     async fn send_data(&self, data: &[u8], addr: SocketAddr) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let socket = self.socket.lock().await;
 
+        let msg_id: u32 = rand::random(); // Added random message ID
+        let msg_ctx = MessageContext {
+            message_id: msg_id as u64,
+            session_id: self.session_id,
+            size: data.len(),
+            message_type: MessageType::Data,
+        };
+
+        let span = info_span!(
+            "message_send",
+            message_id = msg_ctx.message_id,
+            session_id = %msg_ctx.session_id,
+            message_type = %msg_ctx.message_type,
+            size = msg_ctx.size
+        );
+        let _enter = span.enter();
+
         if let Some(rate_limit) = self.config.udp.rate_limit {
             let rate_limit_bytes = rate_limit as f64;
             let sent_data = data.len() as f64;
@@ -129,10 +148,11 @@ impl Tunnel for Server {
         let enable_discovery = self.config.udp.enable_mtu_discovery.unwrap_or(false);
         let discovered_mtu = discover_path_mtu(mtu.into(), addr, enable_discovery);
         let max_size = self.config.udp.max_packet_size.unwrap_or_else(|| calculate_max_payload_size(discovered_mtu));
+        
+        info!("Using max_packet_size: {}", max_size); // Moved line here
 
-        let msg_id: u32 = rand::random(); // Added random message ID
-        let chunk_preview = frame_chunks(&data, max_size - 8, msg_id);
-        let total_chunks = chunk_preview.len() as u32;
+        let chunks = frame_chunks(&data, max_size - 8, msg_id);
+        let total_chunks = chunks.len() as u32;
 
         debug!(
             message_id = msg_id,
@@ -141,7 +161,7 @@ impl Tunnel for Server {
             "Prepared message for sending"
         );
 
-        for (chunk_id, chunk) in chunk_preview.into_iter().enumerate() { // Updated for loop
+        for (chunk_id, chunk) in chunks.into_iter().enumerate() { // Updated for loop
             let ctx = ChunkContext {
                 message_id: msg_id as u64,
                 chunk_id: chunk_id as u32,
@@ -153,8 +173,8 @@ impl Tunnel for Server {
                 message_id = ctx.message_id,
                 chunk_id = ctx.chunk_id,
                 total_chunks = ?ctx.total_chunks,
-                direction = %ctx.direction,
                 size = chunk.len(),
+                direction = %ctx.direction,
                 "Sending chunk"
             );
 
@@ -171,10 +191,28 @@ impl Tunnel for Server {
 
         let reassembled_data = match deframe_chunks(vec![buf[..size].to_vec()]) { // Updated to use deframe_chunks
             Some(data) => data,
-            None => return Err("Failed to reassemble packet".into()),
+            None => {
+                error!("Deframe failed for received packet, discarding");
+                return Err("Failed to reassemble packet".into());
+            }
         };
 
-        trace!( // Added tracing
+        let msg_ctx = MessageContext {
+            message_id: 0, // TODO: parse actual message_id from chunk when available
+            session_id: self.session_id,
+            size: reassembled_data.len(),
+            message_type: MessageType::Data,
+        };
+
+        let span = info_span!(
+            "message_receive",
+            session_id = %msg_ctx.session_id,
+            message_type = %msg_ctx.message_type,
+            size = msg_ctx.size
+        );
+        let _enter = span.enter();
+
+         trace!( // Added tracing
             direction = %Direction::Inbound,
             size = reassembled_data.len(),
             "Received and decompressed message"
@@ -190,4 +228,16 @@ impl Tunnel for Server {
 }
 
 impl Server {
+}
+
+impl fmt::Display for MessageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MessageType::Control => write!(f, "control"),
+            MessageType::Data => write!(f, "data"),
+            MessageType::Handshake => write!(f, "handshake"),
+            MessageType::Heartbeat => write!(f, "heartbeat"),
+            MessageType::Unknown(code) => write!(f, "unknown({})", code),
+        }
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use crate::tunnel::Tunnel;
 use crate::config::Config;
 use crate::net::{calculate_max_payload_size, discover_path_mtu};
 use async_trait::async_trait;
-use log::{info, error};
+use tracing::{info, error, debug, trace}; // Updated to use structured logging
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 use std::sync::Arc;
@@ -11,15 +11,21 @@ use tokio::time::{sleep, Duration}; // For rate limiting
 use socket2::Socket;
 use std::net::UdpSocket as StdUdpSocket;
 use crate::packet_utils::{split_packet, frame_chunks, deframe_chunks};
+use crate::context::{Direction, ChunkContext}; // Added imports
+use uuid::Uuid; // Add this at the top
 
 pub struct Server {
     pub config: Config,
-    pub socket: Arc<Mutex<UdpSocket>>, // Add socket as a field
+    pub socket: Arc<Mutex<UdpSocket>>,
+    pub session_id: Uuid, // Updated struct
 }
 
 #[async_trait]
 impl Tunnel for Server {
     async fn start(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        self.session_id = Uuid::new_v4(); // Inserted line
+        debug!(session_id = %self.session_id, "New server session started");
+
         let addr = format!("{}:{}", self.config.listen_addr, self.config.listen_port);
         info!("Server listening on {}", addr);
 
@@ -67,11 +73,16 @@ impl Tunnel for Server {
             };
 
             info!("Received {} bytes from {}", len, peer);
+            trace!("Processing packet: {:?}", &buf[..len]);
 
             if let Some(rate_limit) = self.config.udp.rate_limit {
                 let rate_limit_bytes = rate_limit as f64;
                 let sent_data = buf.len() as f64;
-                let sleep_duration = Duration::from_secs_f64(sent_data / rate_limit_bytes);
+                let sleep_duration = if rate_limit_bytes > 0.0 {
+                    Duration::from_secs_f64(sent_data / rate_limit_bytes)
+                } else {
+                    Duration::from_secs(0)
+                };
                 sleep(sleep_duration).await;
             }
 
@@ -106,7 +117,11 @@ impl Tunnel for Server {
         if let Some(rate_limit) = self.config.udp.rate_limit {
             let rate_limit_bytes = rate_limit as f64;
             let sent_data = data.len() as f64;
-            let sleep_duration = Duration::from_secs_f64(sent_data / rate_limit_bytes);
+            let sleep_duration = if rate_limit_bytes > 0.0 {
+                Duration::from_secs_f64(sent_data / rate_limit_bytes)
+            } else {
+                Duration::from_secs(0)
+            };
             sleep(sleep_duration).await;
         }
 
@@ -116,9 +131,33 @@ impl Tunnel for Server {
         let max_size = self.config.udp.max_packet_size.unwrap_or_else(|| calculate_max_payload_size(discovered_mtu));
 
         let msg_id: u32 = rand::random(); // Added random message ID
-        let chunks = frame_chunks(&data, max_size - 8, msg_id); // Updated to use frame_chunks
+        let chunk_preview = frame_chunks(&data, max_size - 8, msg_id);
+        let total_chunks = chunk_preview.len() as u32;
 
-        for chunk in chunks {
+        debug!(
+            message_id = msg_id,
+            total_chunks,
+            compressed_size = data.len(),
+            "Prepared message for sending"
+        );
+
+        for (chunk_id, chunk) in chunk_preview.into_iter().enumerate() { // Updated for loop
+            let ctx = ChunkContext {
+                message_id: msg_id as u64,
+                chunk_id: chunk_id as u32,
+                total_chunks: Some(total_chunks),
+                direction: Direction::Outbound,
+            };
+
+            trace!( // Added tracing
+                message_id = ctx.message_id,
+                chunk_id = ctx.chunk_id,
+                total_chunks = ?ctx.total_chunks,
+                direction = %ctx.direction,
+                size = chunk.len(),
+                "Sending chunk"
+            );
+
             socket.send_to(&chunk, addr).await?;
         }
 
@@ -134,6 +173,17 @@ impl Tunnel for Server {
             Some(data) => data,
             None => return Err("Failed to reassemble packet".into()),
         };
+
+        trace!( // Added tracing
+            direction = %Direction::Inbound,
+            size = reassembled_data.len(),
+            "Received and decompressed message"
+        );
+
+        debug!( // Added debug logging
+            size = reassembled_data.len(),
+            "Successfully received and reassembled message"
+        );
 
         Ok(reassembled_data) // Use reassembled_data here
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,6 +26,8 @@ pub struct Server {
 impl Tunnel for Server {
     async fn start(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.session_id = Uuid::new_v4(); // Inserted line
+        let span = info_span!("server_start", session_id = %self.session_id);
+        let _enter = span.enter();
         debug!(session_id = %self.session_id, "New server session started");
 
         let addr = format!("{}:{}", self.config.listen_addr, self.config.listen_port);

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -1,9 +1,8 @@
-use async_trait::async_trait;
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, RwLock};
 use std::sync::Arc;
 use std::net::SocketAddr;
-use tracing::{info, error, debug, trace}; // Updated to use structured logging
+use tracing::{info, error, debug, trace, info_span}; // Updated to use structured logging
 use crate::config::Config;
 use tokio::time::{sleep, Duration}; // For rate limiting
 use crate::net::{calculate_max_payload_size, discover_path_mtu}; // Import for calculating max payload size and discovering MTU
@@ -14,7 +13,8 @@ use lz4::block::{self, CompressionMode};
 use zstd::stream;
 use crate::packet_utils::{frame_chunks, deframe_chunks};
 use rand::random;
-use crate::context::{Direction, ChunkContext};
+use crate::context::{Direction, ChunkContext, MessageContext, MessageType}; // Added MessageContext and MessageType
+use async_trait::async_trait;
 
 #[async_trait]
 pub trait Tunnel {
@@ -124,8 +124,9 @@ impl Tunnel for TunnelImpl {
         let socket = self.socket.clone();  // Clone the Arc pointer for concurrency
         tokio::spawn(async move {
             loop {
+                let socket = socket.read().await;
                 let mut buf = vec![0u8; buffer_size]; // Dynamic buffer size
-                match socket.read().await.recv_from(&mut buf).await {
+                match socket.recv_from(&mut buf).await {
                     Ok((size, src)) => {
                         info!("Received data from {}", src);
                         let data = buf[..size].to_vec();
@@ -151,6 +152,23 @@ impl Tunnel for TunnelImpl {
     async fn send_data(&self, data: &[u8], addr: SocketAddr) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let socket = self.socket.read().await;  // Lock the socket for sending
         
+        let msg_id: u32 = random();
+        let msg_ctx = MessageContext {
+            message_id: msg_id as u64,
+            session_id: self.session_id,
+            size: data.len(),
+            message_type: MessageType::Data,
+        };
+
+        let span = info_span!(
+            "message_send",
+            message_id = msg_ctx.message_id,
+            session_id = %msg_ctx.session_id,
+            message_type = %msg_ctx.message_type,
+            size = msg_ctx.size
+        );
+        let _enter = span.enter();
+
         // Apply rate limiting based on configuration
         if let Some(rate_limit) = self.config.udp.rate_limit {
             let rate_limit_bytes = rate_limit as f64;
@@ -167,16 +185,15 @@ impl Tunnel for TunnelImpl {
         let enable_discovery = self.config.udp.enable_mtu_discovery.unwrap_or(false);
         let discovered_mtu = discover_path_mtu(configured_mtu.into(), addr, enable_discovery);
         let max_packet_size = self.config.udp.max_packet_size.unwrap_or_else(|| calculate_max_payload_size(discovered_mtu.into()));
-        info!("Using max_packet_size: {}", max_packet_size);
+        info!("Using max_packet_size: {}", max_packet_size); // Moved line
 
         // Get the selected compression algorithm
         let compression_algorithm = self.config.compression.algorithm.clone();  // Retrieve compression algorithm
         trace!("Compressing data with algorithm: {}", compression_algorithm);
-        let msg_id: u32 = random();
         // Compress data based on user selection
         let compressed_data = compress_data(&data, &compression_algorithm).await?;
-        let chunk_preview = frame_chunks(&compressed_data, max_packet_size - 8, msg_id);
-        let total_chunks = chunk_preview.len() as u32;
+        let chunks = frame_chunks(&compressed_data, max_packet_size - 8, msg_id);
+        let total_chunks = chunks.len() as u32;
 
         debug!(
             message_id = msg_id,
@@ -184,9 +201,6 @@ impl Tunnel for TunnelImpl {
             compressed_size = compressed_data.len(),
             "Prepared message for sending"
         );
-
-        // Use frame_chunks to chunk the data
-        let chunks = frame_chunks(&compressed_data, max_packet_size - 8, msg_id); // Updated line
 
         // Send each chunk
         for (chunk_id, chunk) in chunks.into_iter().enumerate() {
@@ -201,8 +215,8 @@ impl Tunnel for TunnelImpl {
                 message_id = ctx.message_id,
                 chunk_id = ctx.chunk_id,
                 total_chunks = ?ctx.total_chunks,
-                direction = %ctx.direction,
                 size = chunk.len(),
+                direction = %ctx.direction, // Rearranged fields
                 "Sending chunk"
             );
 
@@ -220,8 +234,26 @@ impl Tunnel for TunnelImpl {
         // Use deframe_chunks to reassemble the data
         let reassembled_data = match deframe_chunks(vec![buf[..size].to_vec()]) { // Updated line
             Some(data) => data,
-            None => return Err("Failed to reassemble packet".into()),
+            None => {
+                error!("Deframe failed for received packet, discarding");
+                return Err("Failed to reassemble packet".into());
+            }
         };
+
+        let msg_ctx = MessageContext {
+            message_id: 0, // TODO: parse actual message_id from chunk when available
+            session_id: self.session_id,
+            size: reassembled_data.len(),
+            message_type: MessageType::Data,
+        };
+
+        let span = info_span!(
+            "message_receive",
+            session_id = %msg_ctx.session_id,
+            message_type = %msg_ctx.message_type,
+            size = msg_ctx.size
+        );
+        let _enter = span.enter();
 
         // Get the selected compression algorithm
         let compression_algorithm = self.config.compression.algorithm.clone();  // Retrieve compression algorithm

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -69,8 +69,14 @@ impl TunnelImpl {
     }
 
     async fn handle_connection(&self, data: Vec<u8>, addr: SocketAddr) {
-        // Process received data
-        info!("Received data from {}: {:?}", addr, data);
+        let span = info_span!(
+            "handle_connection",
+            session_id = %self.session_id,
+            peer = %addr,
+            size = data.len()
+        );
+        let _enter = span.enter();
+        info!("Handling incoming connection");
 
         // Simulate some processing
         if let Err(e) = self.send_data(&data, addr).await {
@@ -140,7 +146,12 @@ impl Tunnel for TunnelImpl {
                 let mut buf = vec![0u8; buffer_size]; // Dynamic buffer size
                 match socket.recv_from(&mut buf).await {
                     Ok((size, src)) => {
-                        info!("Received data from {}", src);
+                        trace!(
+                            session_id = %Uuid::new_v4(),
+                            size = size,
+                            from = %src,
+                            "Received UDP packet"
+                        );
                         let data = buf[..size].to_vec();
                         if let Err(e) = tx.send(data).await {
                             error!("Failed to send data to channel: {}", e);
@@ -187,6 +198,14 @@ impl Tunnel for TunnelImpl {
 
             let sent_data = data.len() as f64;
             let sleep_duration = Duration::from_secs_f64(sent_data / rate_limit_bytes);
+            if sleep_duration > Duration::ZERO {
+                trace!(
+                    message_id = msg_ctx.message_id,
+                    session_id = %msg_ctx.session_id,
+                    delay_ms = sleep_duration.as_millis(),
+                    "Rate limiting delay before sending"
+                );
+            }
 
             // Sleep to respect the rate limit
             sleep(sleep_duration).await;
@@ -251,6 +270,15 @@ impl Tunnel for TunnelImpl {
             payload: raw_chunk,
         };
 
+        trace!(
+            message_id = chunk.message_id,
+            chunk_id = chunk.chunk_id,
+            total_chunks = ?chunk.total_chunks,
+            size = chunk.payload.len(),
+            direction = %Direction::Inbound,
+            "Received and registered chunk"
+        );
+
         let mut assembly = self.assembly_map.write().await;
         let entry = assembly.entry(chunk.message_id).or_default();
         entry.push(chunk);
@@ -298,13 +326,13 @@ impl Tunnel for TunnelImpl {
 
         debug!(
             size = decompressed_data.len(),
-            "Successfully received and reassembled message"
+            "Successfully decoded message"
         );
 
         trace!(
             direction = %Direction::Inbound,
             size = decompressed_data.len(),
-            "Received and decompressed message"
+            "Decompressed payload"
         );
 
         Ok(decompressed_data)

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -11,12 +11,14 @@ use std::net::UdpSocket as StdUdpSocket;
 use uuid::Uuid;
 use lz4::block::{self, CompressionMode};
 use zstd::stream;
-use crate::packet_utils::{frame_chunks, deframe_chunks};
+use crate::packet_utils::frame_chunks;
 use rand::random;
 use crate::context::{Direction, ChunkContext, MessageContext, MessageType}; // Added MessageContext and MessageType
 use async_trait::async_trait;
+use std::collections::HashMap; // New import
+use itertools::Itertools; // Import for sorting
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Chunk {
     pub message_id: u64,
     pub chunk_id: u32,
@@ -36,6 +38,7 @@ pub struct TunnelImpl {
     pub config: Config,
     pub socket: Arc<RwLock<UdpSocket>>,  // Wrap socket in Arc<RwLock> to allow read concurrency
     pub session_id: Uuid, // Added session_id
+    pub assembly_map: Arc<RwLock<HashMap<u64, Vec<Chunk>>>>, // New field
 }
 
 impl TunnelImpl {
@@ -61,6 +64,7 @@ impl TunnelImpl {
             config, 
             socket: Arc::new(RwLock::new(socket)),  // Wrap in Arc<RwLock> for concurrency
             session_id: Uuid::new_v4(), // Initialize session_id
+            assembly_map: Arc::new(RwLock::new(HashMap::new())), // Initialize assembly_map
         })
     }
 
@@ -240,24 +244,37 @@ impl Tunnel for TunnelImpl {
         let (size, _) = socket.recv_from(&mut buf).await?;
 
         let raw_chunk = buf[..size].to_vec();
-        let raw_chunks = match deframe_chunks(vec![raw_chunk]) {
-            Some(chunks) => chunks,
-            None => {
-                error!("Deframe failed for received packet, discarding");
-                return Err("Failed to reassemble packet".into());
-            }
+        let chunk = Chunk {
+            message_id: 0, // TODO: parse actual ID from header
+            chunk_id: 0,
+            total_chunks: Some(1),
+            payload: raw_chunk,
         };
 
-        let chunks: Vec<Chunk> = vec![Chunk {
-            message_id: 0, // TODO: parse from header
-            chunk_id: 0,
-            total_chunks: None,
-            payload: raw_chunks,
-        }];
+        let mut assembly = self.assembly_map.write().await;
+        let entry = assembly.entry(chunk.message_id).or_default();
+        entry.push(chunk);
+
+        let chunks = entry.clone(); // Clone so we can check completeness
+        let complete = match chunks.first().and_then(|c| c.total_chunks) {
+            Some(expected) => chunks.len() as u32 == expected,
+            None => false,
+        };
+
+        if !complete {
+            trace!(message_id = chunks[0].message_id, "Waiting for more chunks...");
+            return Err("Incomplete message, waiting for more chunks.".into());
+        }
+
+        assembly.remove(&chunks[0].message_id); // Clean up after complete
+
+        let reassembled_data: Vec<u8> = chunks
+            .iter()
+            .sorted_by_key(|c| c.chunk_id)
+            .flat_map(|c| c.payload.clone())
+            .collect();
 
         let message_id = chunks.get(0).map(|chunk| chunk.message_id).unwrap_or(0);
-        let reassembled_data: Vec<u8> = chunks.iter().flat_map(|c| c.payload.clone()).collect();
-
         let msg_ctx = MessageContext {
             message_id,
             session_id: self.session_id,

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -3,19 +3,18 @@ use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, RwLock};
 use std::sync::Arc;
 use std::net::SocketAddr;
-use log::{info, error};
+use tracing::{info, error, debug, trace}; // Updated to use structured logging
 use crate::config::Config;
 use tokio::time::{sleep, Duration}; // For rate limiting
 use crate::net::{calculate_max_payload_size, discover_path_mtu}; // Import for calculating max payload size and discovering MTU
 use socket2::Socket;
 use std::net::UdpSocket as StdUdpSocket;
-
-// Correct imports for LZ4 and Zstd compression
+use uuid::Uuid;
 use lz4::block::{self, CompressionMode};
 use zstd::stream;
-use crate::packet_utils::{frame_chunks, deframe_chunks}; // Updated imports
-
-use rand::random; // Added import
+use crate::packet_utils::{frame_chunks, deframe_chunks};
+use rand::random;
+use crate::context::{Direction, ChunkContext};
 
 #[async_trait]
 pub trait Tunnel {
@@ -28,6 +27,7 @@ pub trait Tunnel {
 pub struct TunnelImpl {
     pub config: Config,
     pub socket: Arc<RwLock<UdpSocket>>,  // Wrap socket in Arc<RwLock> to allow read concurrency
+    pub session_id: Uuid, // Added session_id
 }
 
 impl TunnelImpl {
@@ -52,6 +52,7 @@ impl TunnelImpl {
         Ok(TunnelImpl { 
             config, 
             socket: Arc::new(RwLock::new(socket)),  // Wrap in Arc<RwLock> for concurrency
+            session_id: Uuid::new_v4(), // Initialize session_id
         })
     }
 
@@ -107,11 +108,14 @@ pub async fn decompress_data(data: &[u8], algorithm: &str) -> Result<Vec<u8>, Bo
 #[async_trait]
 impl Tunnel for TunnelImpl {
     async fn start(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> { 
+        debug!(session_id = %self.session_id, "Tunnel session started");
+
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(32); // Channel for sending data
 
         // Convert server_addr from String to SocketAddr
         let mut addrs = tokio::net::lookup_host(self.config.server_addr.clone()).await?;
         let server_addr = addrs.next().ok_or("Invalid server address")?;
+        info!("Starting tunnel with server address: {}", server_addr);
 
         // Set the buffer size based on the configuration
         let buffer_size: usize = self.config.udp.buffer_size.unwrap_or(8192);  // Use buffer_size from config or default to 8192 bytes
@@ -167,16 +171,41 @@ impl Tunnel for TunnelImpl {
 
         // Get the selected compression algorithm
         let compression_algorithm = self.config.compression.algorithm.clone();  // Retrieve compression algorithm
-
+        trace!("Compressing data with algorithm: {}", compression_algorithm);
+        let msg_id: u32 = random();
         // Compress data based on user selection
         let compressed_data = compress_data(&data, &compression_algorithm).await?;
+        let chunk_preview = frame_chunks(&compressed_data, max_packet_size - 8, msg_id);
+        let total_chunks = chunk_preview.len() as u32;
+
+        debug!(
+            message_id = msg_id,
+            total_chunks,
+            compressed_size = compressed_data.len(),
+            "Prepared message for sending"
+        );
 
         // Use frame_chunks to chunk the data
-        let msg_id: u32 = random();
         let chunks = frame_chunks(&compressed_data, max_packet_size - 8, msg_id); // Updated line
 
         // Send each chunk
-        for chunk in chunks {
+        for (chunk_id, chunk) in chunks.into_iter().enumerate() {
+            let ctx = ChunkContext {
+                message_id: msg_id as u64,
+                chunk_id: chunk_id as u32,
+                total_chunks: Some(total_chunks),
+                direction: Direction::Outbound,
+            };
+
+            trace!(
+                message_id = ctx.message_id,
+                chunk_id = ctx.chunk_id,
+                total_chunks = ?ctx.total_chunks,
+                direction = %ctx.direction,
+                size = chunk.len(),
+                "Sending chunk"
+            );
+
             socket.send_to(&chunk, addr).await?;
         }
 
@@ -199,6 +228,17 @@ impl Tunnel for TunnelImpl {
 
         // Decompress received data based on user selection
         let decompressed_data = decompress_data(&reassembled_data, &compression_algorithm).await?;
+
+        debug!(
+            size = decompressed_data.len(),
+            "Successfully received and reassembled message"
+        );
+
+        trace!(
+            direction = %Direction::Inbound,
+            size = decompressed_data.len(),
+            "Received and decompressed message"
+        );
 
         Ok(decompressed_data)
     }

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -16,6 +16,14 @@ use rand::random;
 use crate::context::{Direction, ChunkContext, MessageContext, MessageType}; // Added MessageContext and MessageType
 use async_trait::async_trait;
 
+#[derive(Debug)]
+pub struct Chunk {
+    pub message_id: u64,
+    pub chunk_id: u32,
+    pub total_chunks: Option<u32>,
+    pub payload: Vec<u8>,
+}
+
 #[async_trait]
 pub trait Tunnel {
     async fn start(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;  // mutable self
@@ -216,7 +224,7 @@ impl Tunnel for TunnelImpl {
                 chunk_id = ctx.chunk_id,
                 total_chunks = ?ctx.total_chunks,
                 size = chunk.len(),
-                direction = %ctx.direction, // Rearranged fields
+                direction = %ctx.direction,
                 "Sending chunk"
             );
 
@@ -231,17 +239,27 @@ impl Tunnel for TunnelImpl {
         let mut buf = vec![0u8; self.config.udp.buffer_size.unwrap_or(1024)]; // Use dynamic buffer size
         let (size, _) = socket.recv_from(&mut buf).await?;
 
-        // Use deframe_chunks to reassemble the data
-        let reassembled_data = match deframe_chunks(vec![buf[..size].to_vec()]) { // Updated line
-            Some(data) => data,
+        let raw_chunk = buf[..size].to_vec();
+        let raw_chunks = match deframe_chunks(vec![raw_chunk]) {
+            Some(chunks) => chunks,
             None => {
                 error!("Deframe failed for received packet, discarding");
                 return Err("Failed to reassemble packet".into());
             }
         };
 
+        let chunks: Vec<Chunk> = vec![Chunk {
+            message_id: 0, // TODO: parse from header
+            chunk_id: 0,
+            total_chunks: None,
+            payload: raw_chunks,
+        }];
+
+        let message_id = chunks.get(0).map(|chunk| chunk.message_id).unwrap_or(0);
+        let reassembled_data: Vec<u8> = chunks.iter().flat_map(|c| c.payload.clone()).collect();
+
         let msg_ctx = MessageContext {
-            message_id: 0, // TODO: parse actual message_id from chunk when available
+            message_id,
             session_id: self.session_id,
             size: reassembled_data.len(),
             message_type: MessageType::Data,


### PR DESCRIPTION
- Introduced `MessageContext` and `ChunkContext` for consistent tracing
- Implemented structured `info_span!` and `trace!` across client, server, and tunnel
- Added rate-limiting awareness logs in both directions
- Used `Uuid` for session tracking across tunnel flows
- Standardized send/receive log spans with message_id, session_id, and direction
- Implemented chunk framing and deframing via `frame_chunks`/`deframe_chunks`
- Server now echoes data using per-chunk spawn and structured logs
- Improved consistency in log wording and field order