### PR TITLE
feat(tunnel): add control-plane message support and persistent reassembly buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +249,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +325,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,16 +388,22 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "coentrovpn"
 version = "0.1.0"
 dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
  "async-trait",
+ "bincode",
  "clap",
  "env_logger",
  "futures",
+ "hex",
  "itertools 0.14.0",
  "log",
  "lz4",
  "nix",
  "num_cpus",
  "rand 0.9.0",
+ "rand_core 0.9.3",
  "serde",
  "serde_json",
  "socket2",
@@ -408,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +520,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -650,6 +750,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +780,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -738,6 +858,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1007,6 +1133,15 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1300,6 +1435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1530,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1813,6 +1966,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2396,22 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -2268,6 +2449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -2275,6 +2457,18 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,26 +5,33 @@ edition = "2021"
 [features]
 default = []
 pretty-logs = []
+
 [dependencies]
-itertools = "0.14.0" # Add itertools crate
-rand = "0.9.0"
-thiserror = "2.0.12"
-nix = "0.29"
-socket2 = "0.5.9"
-lz4 = "1.24.0"
-zstd = "0.13.3"
-num_cpus = {version = "1.13"}
-tokio-console = "0.1.13"
-tokio = { version = "1.44.2", features = ["full"] }
-uuid = { version = "1.8", features = ["v4"] }
+aead = "0.5"
+aes = "0.8"
+aes-gcm = { version = "0.10", features = ["aes"] }
 async-trait = "0.1"
-log = "0.4"
+bincode = { version = "2.0.1", features = ["derive","serde"] }
+clap = { version = "4.5.35", features = ["derive"] }
 env_logger = "0.11.8"
+futures = "0.3"
+hex ="0.4"
+itertools = "0.14.0"
+log = "0.4"
+lz4 = "1.24.0"
+nix = "0.29"
+num_cpus = {version = "1.13"}
+rand = "0.9.0"
+rand_core = "0.9.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-clap = { version = "4.5.35", features = ["derive"] }
+socket2 = "0.5.9"
+thiserror = "2.0.12"
+tokio = { version = "1.44.2", features = ["full"] }
+tokio-console = "0.1.13"
+tokio-util = "0.7"
 toml = "0.8"
-futures = "0.3"   # For async operations
-tokio-util = "0.7"  # For async utilities
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+uuid = { version = "1.8", features = ["v4","serde"] }
+zstd = "0.13.3"

--- a/Config.toml
+++ b/Config.toml
@@ -21,7 +21,8 @@ send_buffer_size = 1048576  # OS-level send buffer size (in bytes)
 enable_mtu_discovery = true  # Enable dynamic MTU path discovery (true/false)
 
 [encryption]
-enabled = true  # Enable encryption (true/false)
+enabled = true
+key = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"  # 64 hex chars = 32 bytes
 algorithm = "aes-gcm"  # Possible values: "aes-gcm"
 key_size = 256  # AES key size (options: 128, 192, 256)
 iv_size = 12  # Initialization vector size (for AES-GCM)

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,16 +2,18 @@ use async_trait::async_trait;
 use crate::config::Config;
 use crate::context::{MessageContext, MessageType};
 use crate::net::{calculate_max_payload_size, discover_path_mtu};
-use crate::packet_utils::{frame_chunks, deframe_chunks};
-use crate::tunnel::{Tunnel,decompress_data};
+use crate::packet_utils::{frame_chunks, deframe_chunks, ReassemblyBuffer};
+use crate::tunnel::Tunnel;
+use crate::packet_utils::decompress_data;
 use std::net::SocketAddr;
 use std::net::UdpSocket as StdUdpSocket;
 use std::sync::Arc;
+use std::time::Duration; // For rate limiting
 use socket2::Socket;
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 use tokio::task;
-use tokio::time::{sleep, Duration}; // For rate limiting
+use tokio::time::{sleep}; // For rate limiting
 use tracing::{info, error, info_span, trace};
 use uuid::Uuid;
 
@@ -19,7 +21,8 @@ pub struct Client {
     pub config: Config,
     pub socket: Arc<Mutex<UdpSocket>>,
     pub server_addr: SocketAddr,
-    pub session_id: Uuid, // Fix session_id to use Uuid
+    pub session_id: Uuid,
+    pub reassembly_buffer: Arc<Mutex<ReassemblyBuffer>>,
 }
 
 // Implement Clone for Client
@@ -29,7 +32,8 @@ impl Clone for Client {
             config: self.config.clone(),
             socket: Arc::clone(&self.socket),
             server_addr: self.server_addr,
-            session_id: self.session_id, // Clone session_id
+            session_id: self.session_id,
+            reassembly_buffer: Arc::clone(&self.reassembly_buffer),
         }
     }
 }
@@ -73,6 +77,9 @@ impl Tunnel for Client {
         self.socket = Arc::new(Mutex::new(socket));
         info!("Client socket bound to {}", local);
 
+        // Initialize reassembly buffer
+        self.reassembly_buffer = Arc::new(Mutex::new(ReassemblyBuffer::new(Duration::from_secs(10))));
+
         let configured_mtu = self.config.udp.mtu.unwrap_or(1500);
         let enable = self.config.udp.enable_mtu_discovery.unwrap_or(false);
         let target = self.server_addr;
@@ -82,57 +89,20 @@ impl Tunnel for Client {
 
         let message = b"ping from client";
 
-        // Spawn a task for sending data concurrently
-        let socket_clone = Arc::clone(&self.socket); // Clone the Arc pointer
-        let client_clone = self.clone(); // Clone the entire client struct
-
-        task::spawn(async move {
-            let socket = socket_clone.lock().await; // Lock the socket
-
-            // Apply rate limiting based on configuration
-            if let Some(rate_limit) = client_clone.config.udp.rate_limit {
-                let rate_limit_bytes = rate_limit as f64;
-
-                let sent_data = message.len() as f64;
-                let sleep_duration = if rate_limit_bytes > 0.0 {
-                    Duration::from_secs_f64(sent_data / rate_limit_bytes)
-                } else {
-                    Duration::from_secs(0)
-                };
-
-                // Sleep to respect the rate limit
-                sleep(sleep_duration).await;
-            }
-
-            trace!("Sending message to server: {}", String::from_utf8_lossy(message));
-            if message.len() <= max_packet_size {
-                match socket.send_to(message, &client_clone.server_addr).await {
-                    Ok(_) => {
-                        info!("Sent message to server");
-                    }
-                    Err(e) => {
-                        error!("Failed to send message: {}", e);
-                    }
-                }
-            } else {
-                error!("Message size {} exceeds max_packet_size {}, dropping", message.len(), max_packet_size);
-            }
-        });
+        self.send_data(message, self.server_addr).await?;
 
         // Receiving response concurrently
-        let mut buf = [0u8; 1500];
-        let len = {
-            let socket = self.socket.lock().await; // Lock the socket for receiving
-            match socket.recv_from(&mut buf).await {
-                Ok((size, _)) => size,
-                Err(e) => {
-                    error!("Failed to receive data: {}", e);
-                    return Err(Box::new(e));
-                }
-            }
+        let response = self.receive_data().await?;
+        info!("Received from server: {}", String::from_utf8_lossy(&response));
+
+        let heartbeat = b"heartbeat";
+        let hb_ctx = MessageContext {
+            message_id: rand::random::<u64>(),
+            session_id: self.session_id,
+            size: heartbeat.len(),
+            message_type: MessageType::Heartbeat,
         };
-        
-        info!("Received from server: {}", String::from_utf8_lossy(&buf[..len]));
+        self.send_data(heartbeat, self.server_addr).await?;
 
         Ok(())
     }
@@ -185,7 +155,7 @@ impl Tunnel for Client {
             socket.send_to(data, addr).await?;
         } else {
             // Update MTU-based packet sizing
-            let chunks = frame_chunks(data, max_packet_size - 8, msg_id); // Updated to frame chunks
+            let chunks = frame_chunks(data, max_packet_size - 8, msg_id, msg_ctx.message_type.to_u8());
 
             // Send each chunk
             for chunk in chunks {
@@ -212,11 +182,12 @@ impl Tunnel for Client {
             return Err("Received packet exceeds max_packet_size".into());
         }
 
-        // Check if received data fits within max packet size
-        let reassembled_data = match deframe_chunks(vec![buf[..size].to_vec()]) { // Updated to use deframe_chunks
+        let mut buffer = self.reassembly_buffer.lock().await;
+        buffer.purge_expired();
+        let reassembled_data = match buffer.insert(buf[..size].to_vec()) {
             Some(data) => data,
             None => {
-                error!("Deframe failed for received packet, discarding");
+                error!("Reassembly failed: awaiting more chunks");
                 return Err("Failed to reassemble packet".into());
             }
         };
@@ -237,10 +208,20 @@ impl Tunnel for Client {
         let span = info_span!(
             "message_receive",
             session_id = %msg_ctx.session_id,
-            message_type = %msg_ctx.message_type,
+            message_type = %msg_ctx.message_type,  // using Display impl
             size = msg_ctx.size
         );
         let _enter = span.enter();
+
+        match msg_ctx.message_type {
+            MessageType::Control => {
+                trace!("Received Control message: {:?}", String::from_utf8_lossy(&reassembled_data));
+            }
+            MessageType::Heartbeat => {
+                trace!("Received Heartbeat message: {:?}", String::from_utf8_lossy(&reassembled_data));
+            }
+            _ => {}
+        }
 
         Ok(decompressed_data) // Updated return value
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use hex;
 use serde::Deserialize;
 use std::{env, fs};
 use tracing::info;
@@ -18,6 +19,15 @@ pub struct LoggingConfig {
 pub struct CompressionConfig {
     pub algorithm: String,  // Compression algorithm choice
     pub min_compression_size: Option<usize>, // Minimum compression size
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct EncryptionConfig {
+    pub enabled: bool,
+    pub key: String, // Expecting 64 hex chars representing 32 bytes
+    pub algorithm: Option<String>, // e.g. "aes-gcm"
+    pub key_size: Option<u16>,     // Optional validation
+    pub iv_size: Option<u8>,       // Optional validation
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -42,6 +52,7 @@ pub struct Config {
     pub logging: LoggingConfig,
     pub compression: CompressionConfig,
     pub udp: UdpConfig,
+    pub encryption: EncryptionConfig,
 }
 
 impl Config {
@@ -109,6 +120,14 @@ impl Config {
         if let Some(size) = self.compression.min_compression_size {
             if size < 64 {
                 return Err(format!("compression.min_compression_size must be >= 64, got {}", size));
+            }
+        }
+        if self.encryption.enabled {
+            if self.encryption.key.len() != 64 {
+                return Err("encryption.key must be 64 hex characters (32 bytes)".into());
+            }
+            if let Err(e) = hex::decode(&self.encryption.key) {
+                return Err(format!("Invalid hex in encryption.key: {}", e));
             }
         }
         Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,14 +1,15 @@
 use std::fmt;
 use std::net::SocketAddr;
 use uuid::Uuid;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Direction {
     Inbound,
     Outbound,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageContext {
     pub message_id: u64,
     pub session_id: Uuid,
@@ -16,7 +17,7 @@ pub struct MessageContext {
     pub message_type: MessageType,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChunkContext {
     pub message_id: u64,
     pub chunk_id: u32,
@@ -24,7 +25,7 @@ pub struct ChunkContext {
     pub direction: Direction,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MessageType {
     Control,
     Data,
@@ -32,6 +33,28 @@ pub enum MessageType {
     Heartbeat,
     #[allow(dead_code)]
     Unknown(u8),
+}
+
+impl MessageType {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            MessageType::Control => 2,
+            MessageType::Data => 0,
+            MessageType::Handshake => 4,
+            MessageType::Heartbeat => 3,
+            MessageType::Unknown(v) => *v,
+        }
+    }
+
+    pub fn from_u8(value: u8) -> MessageType {
+        match value {
+            0 => MessageType::Data,
+            2 => MessageType::Control,
+            3 => MessageType::Heartbeat,
+            4 => MessageType::Handshake,
+            other => MessageType::Unknown(other),
+        }
+    }
 }
 
 impl fmt::Display for Direction {
@@ -43,8 +66,25 @@ impl fmt::Display for Direction {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ControlPayload {
+    Version { version: String },
+    Ack { message_id: u64 },
+    Disconnect,
+}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakePayload {
+    pub session_id: Uuid,
+    pub client_info: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatPayload {
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionContext {
     pub session_id: Uuid,
     pub peer_addr: Option<SocketAddr>,

--- a/src/crypto/aes_gcm.rs
+++ b/src/crypto/aes_gcm.rs
@@ -1,0 +1,29 @@
+use aes_gcm::{Aes256Gcm, Key, Nonce}; // Or `Aes128Gcm`
+use aes_gcm::aead::{Aead, KeyInit, OsRng, rand_core::RngCore};
+
+
+pub struct AesGcmEncryptor {
+    cipher: Aes256Gcm,
+}
+
+impl AesGcmEncryptor {
+    pub fn new(key_bytes: &[u8; 32]) -> Self {
+        let key = Key::<Aes256Gcm>::from_slice(key_bytes);
+        let cipher = Aes256Gcm::new(key);
+        Self { cipher }
+    }
+
+    pub fn encrypt(&self, plaintext: &[u8], aad: &[u8]) -> Result<(Vec<u8>, [u8; 12]), aes_gcm::Error> {
+        let mut nonce_bytes = [0u8; 12];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes); // 96-bits; unique per message
+        let ciphertext = self.cipher.encrypt(nonce, aes_gcm::aead::Payload { msg: plaintext, aad })?;
+        Ok((ciphertext, nonce_bytes))
+    }
+
+    pub fn decrypt(&self, ciphertext: &[u8], nonce_bytes: &[u8; 12], aad: &[u8]) -> Result<Vec<u8>, aes_gcm::Error> {
+        let nonce = Nonce::from_slice(nonce_bytes);
+        let plaintext = self.cipher.decrypt(nonce, aes_gcm::aead::Payload { msg: ciphertext, aad })?;
+        Ok(plaintext)
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,1 @@
+pub mod aes_gcm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod config;
 pub mod context;
+pub mod crypto;
 pub mod logging;
 pub mod net;
 pub mod packet_utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use coentrovpn::client::Client;
 use coentrovpn::config::Config;
 use coentrovpn::logging::init_logging; // Updated import
+use coentrovpn::packet_utils::ReassemblyBuffer;
 use coentrovpn::server::Server;
 use coentrovpn::tunnel::Tunnel;
 use num_cpus;  // Import the num_cpus crate
@@ -12,7 +13,6 @@ use tokio::runtime::Builder;  // Import Builder to manually create the runtime
 use tokio::sync::Mutex; // Add this import for Mutex
 use tracing::{info, debug}; // Updated import
 use uuid::Uuid;
-
 
 #[derive(Parser, Debug)]
 #[command(name = "coentrovpn", version)]
@@ -85,6 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
                     config,
                     socket: Arc::clone(&socket),
                     session_id: Uuid::new_v4(),
+                    reassembly_buffer: Arc::new(Mutex::new(ReassemblyBuffer::new(std::time::Duration::from_secs(10)))),
                 }; // Declare server as mutable
                 server.start().await?;  // Now we can call start() on a mutable reference
             }
@@ -95,6 +96,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
                     socket: Arc::clone(&socket),
                     server_addr,
                     session_id: Uuid::new_v4(),
+                    reassembly_buffer: Arc::new(Mutex::new(ReassemblyBuffer::new(std::time::Duration::from_secs(10)))),
                 };
                 client.start().await?;  // Now we can call start() on a mutable reference
             }

--- a/src/packet_utils.rs
+++ b/src/packet_utils.rs
@@ -1,5 +1,7 @@
-use std::collections::{BTreeMap,HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant};
+use tokio::task;
+use std::io::Read;
 
 pub fn split_packet(data: &[u8], max_size: usize) -> Vec<Vec<u8>> {
     data.chunks(max_size).map(|chunk| chunk.to_vec()).collect()
@@ -14,30 +16,33 @@ pub struct PacketHeader {
     pub msg_id: u32,
     pub chunk_id: u16,
     pub total_chunks: u16,
+    pub message_type: u8,
 }
 
 impl PacketHeader {
-    pub fn serialize(&self) -> [u8; 8] {
-        let mut buf = [0u8; 8];
+    pub fn serialize(&self) -> [u8; 9] {
+        let mut buf = [0u8; 9];
         buf[..4].copy_from_slice(&self.msg_id.to_be_bytes());
         buf[4..6].copy_from_slice(&self.chunk_id.to_be_bytes());
         buf[6..8].copy_from_slice(&self.total_chunks.to_be_bytes());
+        buf[8] = self.message_type;
         buf
     }
 
     pub fn deserialize(buf: &[u8]) -> Option<(Self, &[u8])> {
-        if buf.len() < 8 {
+        if buf.len() < 9 {
             return None;
         }
         let msg_id = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]);
         let chunk_id = u16::from_be_bytes([buf[4], buf[5]]);
         let total_chunks = u16::from_be_bytes([buf[6], buf[7]]);
-        let header = PacketHeader { msg_id, chunk_id, total_chunks };
-        Some((header, &buf[8..]))
+        let message_type = buf[8];
+        let header = PacketHeader { msg_id, chunk_id, total_chunks, message_type };
+        Some((header, &buf[9..]))
     }
 }
 
-pub fn frame_chunks(data: &[u8], max_chunk_size: usize, msg_id: u32) -> Vec<Vec<u8>> {
+pub fn frame_chunks(data: &[u8], max_chunk_size: usize, msg_id: u32, message_type: u8) -> Vec<Vec<u8>> {
     let chunks = data.chunks(max_chunk_size).collect::<Vec<_>>();
     let total_chunks = chunks.len() as u16;
     chunks.into_iter().enumerate().map(|(i, chunk)| {
@@ -45,6 +50,7 @@ pub fn frame_chunks(data: &[u8], max_chunk_size: usize, msg_id: u32) -> Vec<Vec<
             msg_id,
             chunk_id: i as u16,
             total_chunks,
+            message_type,
         };
         let mut framed = header.serialize().to_vec();
         framed.extend_from_slice(chunk);
@@ -84,7 +90,6 @@ pub fn deframe_chunks(packets: Vec<Vec<u8>>) -> Option<Vec<u8>> {
 
     Some(result)
 }
-
 
 pub struct ReassemblyBuffer {
     messages: HashMap<u32, MessageChunks>,
@@ -138,6 +143,68 @@ impl ReassemblyBuffer {
 
     pub fn purge_expired(&mut self) {
         let now = Instant::now();
+        let before = self.messages.len();
         self.messages.retain(|_, v| now.duration_since(v.last_update) < self.expiration);
+        let after = self.messages.len();
+        if before != after {
+            tracing::debug!("Purged {} expired reassembly entries", before - after);
+        }
     }
+}
+
+pub async fn compress_data(
+    data: &[u8],
+    algorithm: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let input = data.to_vec();
+    let result = match algorithm {
+        "lz4" => {
+            task::spawn_blocking(move || {
+                let mut encoder = lz4::EncoderBuilder::new().build(Vec::new())?;
+                std::io::copy(&mut &input[..], &mut encoder)?;
+                let (compressed, result) = encoder.finish();
+                result?;
+                Ok(compressed)
+            })
+            .await?
+        }
+        "zstd" => {
+            task::spawn_blocking(move || {
+                let compressed = zstd::stream::encode_all(&input[..], 1)?;
+                Ok(compressed)
+            })
+            .await?
+        }
+        _ => Err(format!("Unsupported compression algorithm: {}", algorithm).into()),
+    };
+    result
+}
+
+pub async fn decompress_data(
+    data: &[u8],
+    algorithm: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    let input = data.to_vec();
+    let result = match algorithm {
+        "lz4" => {
+            task::spawn_blocking(move || {
+                let mut decoder = lz4::Decoder::new(&input[..])?;
+                let mut decompressed = Vec::new();
+                decoder.read_to_end(&mut decompressed)?;
+                Ok(decompressed)
+            })
+            .await?
+        }
+        "zstd" => {
+            task::spawn_blocking(move || {
+                let mut decoder = zstd::stream::Decoder::new(&input[..])?;
+                let mut decompressed = Vec::new();
+                decoder.read_to_end(&mut decompressed)?;
+                Ok(decompressed)
+            })
+            .await?
+        }
+        _ => Err(format!("Unsupported decompression algorithm: {}", algorithm).into()),
+    };
+    result
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,16 +2,18 @@ use async_trait::async_trait;
 use crate::config::Config;
 use crate::context::{Direction, ChunkContext, MessageContext, MessageType};
 use crate::net::{calculate_max_payload_size, discover_path_mtu};
-use crate::packet_utils::{split_packet, frame_chunks, deframe_chunks};
-use crate::tunnel::{Tunnel, decompress_data};
+use crate::packet_utils::{split_packet, frame_chunks, deframe_chunks, ReassemblyBuffer}; // Added ReassemblyBuffer
+use crate::tunnel::Tunnel;
+use crate::packet_utils::decompress_data;
 use socket2::Socket;
 use std::fmt;
 use std::net::SocketAddr;
 use std::net::UdpSocket as StdUdpSocket;
 use std::sync::Arc;
+use std::time::Duration; // Included Duration
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
-use tokio::time::{sleep, Duration}; // For rate limiting
+use tokio::time::{sleep}; // For rate limiting
 use tracing::{info, error, debug, trace}; // Updated to use structured logging
 use tracing::info_span;
 use uuid::Uuid;
@@ -20,6 +22,7 @@ pub struct Server {
     pub config: Config,
     pub socket: Arc<Mutex<UdpSocket>>,
     pub session_id: Uuid, // Updated struct
+    pub reassembly_buffer: Arc<Mutex<ReassemblyBuffer>>, // Added reassembly_buffer
 }
 
 #[async_trait]
@@ -55,6 +58,8 @@ impl Tunnel for Server {
         let socket = Arc::new(Mutex::new(socket));
         self.socket = socket;
 
+        self.reassembly_buffer = Arc::new(Mutex::new(ReassemblyBuffer::new(Duration::from_secs(10)))); // Added reassembly_buffer initialization
+
         // Perform MTU discovery once
         let mtu = self.config.udp.mtu.unwrap_or(1500);
         let enable_discovery = self.config.udp.enable_mtu_discovery.unwrap_or(false);
@@ -66,8 +71,8 @@ impl Tunnel for Server {
             discovered_mtu, max_size
         );
 
-        let mut buf = [0u8; 1500];
         loop {
+            let mut buf = [0u8; 1500];
             let (len, peer) = match self.socket.lock().await.recv_from(&mut buf).await {
                 Ok(res) => res,
                 Err(e) => {
@@ -76,41 +81,18 @@ impl Tunnel for Server {
                 }
             };
 
-            info!("Received {} bytes from {}", len, peer);
-            trace!("Processing packet: {:?}", &buf[..len]);
-
-            if let Some(rate_limit) = self.config.udp.rate_limit {
-                let rate_limit_bytes = rate_limit as f64;
-                let sent_data = buf.len() as f64;
-                let sleep_duration = if rate_limit_bytes > 0.0 {
-                    Duration::from_secs_f64(sent_data / rate_limit_bytes)
-                } else {
-                    Duration::from_secs(0)
-                };
-                sleep(sleep_duration).await;
-            }
-
-            let chunks = if len <= max_size {
-                vec![buf[..len].to_vec()]
-            } else {
-                split_packet(&buf[..len], max_size)
+            let received_data = match self.receive_data().await {
+                Ok(data) => data,
+                Err(e) => {
+                    error!("Failed to receive or process data: {}", e);
+                    continue;
+                }
             };
 
-            let socket_clone = Arc::clone(&self.socket);
-            let peer_clone = peer.clone();
+            info!("Received {} bytes from {}: {:?}", received_data.len(), peer, String::from_utf8_lossy(&received_data));
 
-            for chunk in chunks {
-                let socket_clone = Arc::clone(&socket_clone);
-                let chunk_clone = chunk.clone();
-
-                tokio::spawn(async move {
-                    let socket = socket_clone.lock().await;
-                    if let Err(e) = socket.send_to(&chunk_clone, peer_clone).await {
-                        error!("Failed to send data to {}: {}", peer_clone, e);
-                    }
-
-                    info!("Echoed {} bytes back to {}", chunk_clone.len(), peer_clone);
-                });
+            if let Err(e) = self.send_data(&received_data, peer).await {
+                error!("Failed to send response to {}: {}", peer, e);
             }
         }
     }
@@ -153,7 +135,7 @@ impl Tunnel for Server {
         
         info!("Using max_packet_size: {}", max_size); // Moved line here
 
-        let chunks = frame_chunks(&data, max_size - 8, msg_id);
+        let chunks = frame_chunks(&data, max_size - 8, msg_id, msg_ctx.message_type.to_u8());
         let total_chunks = chunks.len() as u32;
 
         debug!(
@@ -191,23 +173,20 @@ impl Tunnel for Server {
         let mut buf = vec![0u8; 1024];
         let (size, _) = socket.recv_from(&mut buf).await?;
 
-        let mut data = match deframe_chunks(vec![buf[..size].to_vec()]) { // Updated to use deframe_chunks
+        let mut buffer = self.reassembly_buffer.lock().await; // Updated to use ReassemblyBuffer
+        buffer.purge_expired();
+        let reassembled_data = match buffer.insert(buf[..size].to_vec()) {
             Some(data) => data,
             None => {
-                error!("Deframe failed for received packet, discarding");
+                error!("Reassembly failed: awaiting more chunks");
                 return Err("Failed to reassemble packet".into());
             }
         };
 
-        data = decompress_data(
-            &data,
-            &self.config.compression.algorithm
-        ).await?;
-
         let msg_ctx = MessageContext {
             message_id: 0, // TODO: parse actual message_id from chunk when available
             session_id: self.session_id,
-            size: data.len(),
+            size: reassembled_data.len(),
             message_type: MessageType::Data,
         };
 
@@ -221,16 +200,26 @@ impl Tunnel for Server {
 
          trace!( // Added tracing
             direction = %Direction::Inbound,
-            size = data.len(),
+            size = reassembled_data.len(),
             "Received and decompressed message"
         );
 
         debug!( // Added debug logging
-            size = data.len(),
+            size = reassembled_data.len(),
             "Successfully received and reassembled message"
         );
 
-        Ok(data) // Use data here
+        match msg_ctx.message_type {
+            MessageType::Control => {
+                trace!("Received Control message: {:?}", String::from_utf8_lossy(&reassembled_data));
+            }
+            MessageType::Heartbeat => {
+                trace!("Received Heartbeat message: {:?}", String::from_utf8_lossy(&reassembled_data));
+            }
+            _ => {}
+        }
+
+        Ok(reassembled_data) // Use reassembled_data here
     }
 }
 

--- a/src/tunnel.rs
+++ b/src/tunnel.rs
@@ -1,3 +1,16 @@
+use crate::config::Config;
+use crate::context::{MessageContext, MessageType};
+use crate::packet_utils::{frame_chunks, PacketHeader, ReassemblyBuffer, compress_data, decompress_data};
+use crate::crypto::aes_gcm::AesGcmEncryptor;
+use tracing::{debug, trace};
+use std::io::Read;
+use tokio::task;
+use tokio::net::UdpSocket;
+use std::sync::Arc;
+use std::time::Duration;
+use bincode::config::standard;
+use bincode::serde::{encode_to_vec as serialize, decode_from_slice as deserialize};
+
 #[async_trait::async_trait]
 pub trait Tunnel: Send + Sync {
     async fn start(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -5,15 +18,11 @@ pub trait Tunnel: Send + Sync {
     async fn receive_data(&self) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
-use crate::config::Config;
-use crate::context::{MessageContext, MessageType};
-use crate::packet_utils::frame_chunks;
-use tracing::{debug, trace};
-use std::io::Read;
-use tokio::task;
-
 pub struct TunnelImpl {
     pub config: Config,
+    encryptor: Option<AesGcmEncryptor>,
+    socket: Arc<tokio::sync::Mutex<UdpSocket>>,
+    pub reassembly_buffer: Arc<tokio::sync::Mutex<ReassemblyBuffer>>,
 }
 
 impl TunnelImpl {
@@ -46,13 +55,41 @@ impl TunnelImpl {
         let algorithm = &self.config.compression.algorithm;
         let min_size = self.config.compression.min_compression_size.unwrap_or(0);
 
-        let (payload, compressed) = Self::maybe_compress_data(
+        let (mut payload, compressed) = Self::maybe_compress_data(
             &data,
             algorithm,
             min_size,
             &msg_ctx.message_type,
         )
         .await?;
+
+        let mut encrypted = false;
+
+        match msg_ctx.message_type {
+            MessageType::Control | MessageType::Heartbeat | MessageType::Handshake => {
+                trace!("Serializing control-plane message: {:?}", msg_ctx.message_type);
+                payload = serialize(&data, standard())
+                    .map_err(|e| format!("Control message serialization failed: {:?}", e))?;
+            }
+            _ => { /* existing logic */ }
+        }
+
+        if let Some(ref encryptor) = self.encryptor {
+            if matches!(msg_ctx.message_type, MessageType::Data) {
+                let aad = b""; // optionally pass metadata
+                let (ciphertext, nonce) = encryptor.encrypt(&payload, aad)
+                    .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(format!("Encryption failed: {:?}", e)))?;
+                let mut buf = Vec::with_capacity(12 + ciphertext.len());
+                buf.extend_from_slice(&nonce);
+                buf.extend_from_slice(&ciphertext);
+                payload = buf;
+                encrypted = true;
+            }
+        }
+
+        if encrypted {
+            debug!("AES-GCM encryption applied: {} -> {} bytes", data.len(), payload.len());
+        }
 
         if compressed {
             debug!(
@@ -65,64 +102,104 @@ impl TunnelImpl {
             trace!("Compression skipped (type: {:?}, size: {})", msg_ctx.message_type, data.len());
         }
 
-        let chunks = frame_chunks(&payload, 1400 - 8, msg_ctx.message_id as u32); // example MTU logic
+        let chunks = frame_chunks(&payload, 1400 - 8, msg_ctx.message_id as u32, msg_ctx.message_type.to_u8()); // example MTU logic
         Ok(chunks)
     }
-}
 
-async fn compress_data(
-    data: &[u8],
-    algorithm: &str,
-) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    let input = data.to_vec();
-    let result = match algorithm {
-        "lz4" => {
-            task::spawn_blocking(move || {
-                let mut encoder = lz4::EncoderBuilder::new().build(Vec::new())?;
-                std::io::copy(&mut &input[..], &mut encoder)?;
-                let (compressed, result) = encoder.finish();
-                result?;
-                Ok(compressed)
-            })
-            .await?
+    pub async fn decrypt_if_needed(
+        &self,
+        data: &[u8],
+        msg_type: &MessageType,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(ref encryptor) = self.encryptor {
+            if matches!(msg_type, MessageType::Data) {
+                if data.len() < 12 {
+                    return Err("Encrypted payload too short (missing nonce)".into());
+                }
+                let (nonce_bytes, ciphertext) = data.split_at(12);
+                let mut nonce_array = [0u8; 12];
+                nonce_array.copy_from_slice(nonce_bytes);
+                let aad = b""; // optionally bind to metadata
+                let plaintext = encryptor.decrypt(ciphertext, &nonce_array, aad)
+                    .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(format!("Decryption failed: {:?}", e)))?;
+                return Ok(plaintext);
+            }
         }
-        "zstd" => {
-            task::spawn_blocking(move || {
-                let compressed = zstd::stream::encode_all(&input[..], 1)?;
-                Ok(compressed)
-            })
-            .await?
-        }
-        _ => Err(format!("Unsupported compression algorithm: {}", algorithm).into()),
-    };
-    result
-}
+        Ok(data.to_vec())
+    }
 
-pub async fn decompress_data(
-    data: &[u8],
-    algorithm: &str,
-) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    let input = data.to_vec();
-    let result = match algorithm {
-        "lz4" => {
-            task::spawn_blocking(move || {
-                let mut decoder = lz4::Decoder::new(&input[..])?;
-                let mut decompressed = Vec::new();
-                decoder.read_to_end(&mut decompressed)?;
-                Ok(decompressed)
-            })
-            .await?
+    pub async fn receive_data(&self) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        let socket = self.socket.lock().await;
+        let mut buf = [0u8; 1500];
+        let (len, _peer) = socket.recv_from(&mut buf).await?;
+        let received_payload = &buf[..len];
+
+        let (header, payload) = PacketHeader::deserialize(received_payload)
+            .ok_or("Failed to parse packet header")?;
+
+        let msg_type = match header.message_type {
+            0 => MessageType::Data,
+            1 => MessageType::Control,
+            2 => MessageType::Control,
+            3 => MessageType::Heartbeat,
+            4 => MessageType::Handshake,
+            v => MessageType::Unknown(v),
+        };
+
+        let mut buffer = self.reassembly_buffer.lock().await;
+        if let Some(assembled) = buffer.insert(received_payload.to_vec()) {
+            let decrypted = self.decrypt_if_needed(&assembled, &msg_type).await?;
+
+            let final_payload = if matches!(msg_type, MessageType::Data) {
+                let algorithm = &self.config.compression.algorithm;
+                match decompress_data(&decrypted, algorithm).await {
+                    Ok(decompressed) => decompressed,
+                    Err(e) => {
+                        tracing::warn!("Decompression failed: {}", e);
+                        decrypted
+                    }
+                }
+            } else {
+                decrypted
+            };
+
+            match msg_type {
+                MessageType::Control => {
+                    match deserialize::<crate::context::ControlPayload, _>(&final_payload, standard()) {
+                        Ok((payload, _)) => {
+                            trace!("Deserialized ControlPayload: {:?}", payload);
+                        }
+                        Err(e) => {
+                            trace!("Failed to deserialize ControlPayload: {:?}", e);
+                        }
+                    }
+                }
+                MessageType::Heartbeat => {
+                    match deserialize::<crate::context::HeartbeatPayload, _>(&final_payload, standard()) {
+                        Ok((payload, _)) => {
+                            trace!("Deserialized HeartbeatPayload: {:?}", payload);
+                        }
+                        Err(e) => {
+                            trace!("Failed to deserialize HeartbeatPayload: {:?}", e);
+                        }
+                    }
+                }
+                MessageType::Handshake => {
+                    match deserialize::<crate::context::HandshakePayload, _>(&final_payload, standard()) {
+                        Ok((payload, _)) => {
+                            trace!("Deserialized HandshakePayload: {:?}", payload);
+                        }
+                        Err(e) => {
+                            trace!("Failed to deserialize HandshakePayload: {:?}", e);
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            return Ok(final_payload);
+        } else {
+            return Err("Incomplete message: awaiting more chunks".into());
         }
-        "zstd" => {
-            task::spawn_blocking(move || {
-                let mut decoder = zstd::stream::Decoder::new(&input[..])?;
-                let mut decompressed = Vec::new();
-                decoder.read_to_end(&mut decompressed)?;
-                Ok(decompressed)
-            })
-            .await?
-        }
-        _ => Err(format!("Unsupported decompression algorithm: {}", algorithm).into()),
-    };
-    result
+    }
 }

--- a/tests/aes_gcm_tests.rs
+++ b/tests/aes_gcm_tests.rs
@@ -1,0 +1,46 @@
+use coentrovpn::crypto::aes_gcm::AesGcmEncryptor;
+
+#[test]
+fn test_aes_gcm_encrypt_decrypt_roundtrip() {
+    let key = [0u8; 32];
+    let encryptor = AesGcmEncryptor::new(&key);
+
+    let plaintext = b"The quick brown fox jumps over the lazy dog";
+    let aad = b"associated data";
+
+    let (ciphertext, nonce) = encryptor.encrypt(plaintext, aad).expect("encryption failed");
+    let decrypted = encryptor.decrypt(&ciphertext, &nonce, aad).expect("decryption failed");
+
+    assert_eq!(plaintext.to_vec(), decrypted);
+}
+
+#[test]
+fn test_aes_gcm_decrypt_with_wrong_key_fails() {
+    let key1 = [0u8; 32];
+    let key2 = [1u8; 32];
+    let enc1 = AesGcmEncryptor::new(&key1);
+    let enc2 = AesGcmEncryptor::new(&key2);
+
+    let plaintext = b"secret message";
+    let aad = b"metadata";
+
+    let (ciphertext, nonce) = enc1.encrypt(plaintext, aad).unwrap();
+    let result = enc2.decrypt(&ciphertext, &nonce, aad);
+
+    assert!(result.is_err(), "Decryption with wrong key should fail");
+}
+
+#[test]
+fn test_aes_gcm_decrypt_with_wrong_aad_fails() {
+    let key = [7u8; 32];
+    let encryptor = AesGcmEncryptor::new(&key);
+
+    let plaintext = b"auth-tag-sensitive";
+    let aad_good = b"correct-aad";
+    let aad_bad = b"wrong-aad";
+
+    let (ciphertext, nonce) = encryptor.encrypt(plaintext, aad_good).unwrap();
+    let result = encryptor.decrypt(&ciphertext, &nonce, aad_bad);
+
+    assert!(result.is_err(), "Decryption with incorrect AAD should fail");
+}

--- a/tests/compression_tests.rs
+++ b/tests/compression_tests.rs
@@ -1,0 +1,39 @@
+use coentrovpn::packet_utils::{compress_data, decompress_data};
+use tokio::runtime::Runtime;
+
+#[test]
+fn test_lz4_compression_roundtrip() {
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        let original = b"The quick brown fox jumps over the lazy dog.".repeat(10);
+        let compressed = compress_data(&original, "lz4").await.expect("compression failed");
+        assert!(compressed.len() < original.len(), "lz4 should compress");
+        let decompressed = decompress_data(&compressed, "lz4").await.expect("decompression failed");
+        assert_eq!(original, decompressed);
+    });
+}
+
+#[test]
+fn test_zstd_compression_roundtrip() {
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        let original = b"Rustaceans are fearless and fast.".repeat(10);
+        let compressed = compress_data(&original, "zstd").await.expect("compression failed");
+        assert!(compressed.len() < original.len(), "zstd should compress");
+        let decompressed = decompress_data(&compressed, "zstd").await.expect("decompression failed");
+        assert_eq!(original, decompressed);
+    });
+}
+
+#[test]
+fn test_invalid_algorithm_fails() {
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        let original = b"invalid algorithm test";
+        let compressed = compress_data(original, "unsupported_algo").await;
+        assert!(compressed.is_err(), "Should fail with unknown algorithm");
+
+        let decompressed = decompress_data(original, "unsupported_algo").await;
+        assert!(decompressed.is_err(), "Should fail with unknown algorithm");
+    });
+}

--- a/tests/packet_utils_tests.rs
+++ b/tests/packet_utils_tests.rs
@@ -1,0 +1,64 @@
+use coentrovpn::packet_utils::{PacketHeader, frame_chunks, deframe_chunks, ReassemblyBuffer};
+use std::collections::HashSet;
+use std::time::Duration;
+
+#[test]
+fn test_packet_header_roundtrip() {
+    let header = PacketHeader {
+        msg_id: 1234,
+        chunk_id: 1,
+        total_chunks: 3,
+        message_type: 0xAB,
+    };
+    let serialized = header.serialize();
+    let (parsed, _) = PacketHeader::deserialize(&serialized).expect("Deserialization failed");
+    assert_eq!(header.msg_id, parsed.msg_id);
+    assert_eq!(header.chunk_id, parsed.chunk_id);
+    assert_eq!(header.total_chunks, parsed.total_chunks);
+    assert_eq!(header.message_type, parsed.message_type);
+}
+
+#[test]
+fn test_frame_and_deframe_chunks() {
+    let payload = b"hello world, this is a long payload that will be chunked".to_vec();
+    let msg_id = 42;
+    let message_type = 0x01;
+    let chunks = frame_chunks(&payload, 20, msg_id, message_type);
+    assert!(chunks.len() > 1);
+
+    let reassembled = deframe_chunks(chunks).expect("Deframe failed");
+    assert_eq!(reassembled, payload);
+}
+
+#[test]
+fn test_reassembly_buffer_ordered_insert() {
+    let mut buffer = ReassemblyBuffer::new(Duration::from_secs(10));
+    let payload = b"chunked payload data".to_vec();
+    let chunks = frame_chunks(&payload, 8, 100, 0x01);
+
+    let mut assembled = None;
+    for chunk in chunks {
+        assembled = buffer.insert(chunk);
+    }
+
+    assert_eq!(assembled, Some(payload));
+}
+
+#[test]
+fn test_reassembly_buffer_unordered_insert() {
+    let mut buffer = ReassemblyBuffer::new(Duration::from_secs(10));
+    let payload = b"unordered chunked payload test".to_vec();
+    let mut chunks = frame_chunks(&payload, 10, 200, 0x02);
+    let mut inserted: HashSet<Vec<u8>> = HashSet::new();
+
+    // Shuffle order
+    chunks.sort_by_key(|_| rand::random::<u8>());
+
+    let mut assembled = None;
+    for chunk in chunks {
+        inserted.insert(chunk.clone());
+        assembled = buffer.insert(chunk);
+    }
+
+    assert_eq!(assembled, Some(payload));
+}


### PR DESCRIPTION
- Implemented serialization and deserialization for MessageType::{Control, Heartbeat, Handshake}
  using bincode v2 with standard config
- Hooked control-plane message handling into send_data() and receive_data() paths
- Added persistent ReassemblyBuffer to TunnelImpl to support out-of-order chunked messages
- Refactored receive_data() to reassemble before decryption and decompression
- Ensured control messages skip compression and encryption phases
- Improved trace logging for control-plane payloads and error paths