### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
Potential fix for [https://github.com/thcp/CoentroVPN/security/code-scanning/3](https://github.com/thcp/CoentroVPN/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the tasks performed in the workflow, the minimal required permissions are likely `contents: read`. This allows the workflow to read the repository's contents without granting unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
